### PR TITLE
Use primitive types

### DIFF
--- a/src/main/java/io/symphonia/FibonacciLambda.java
+++ b/src/main/java/io/symphonia/FibonacciLambda.java
@@ -64,11 +64,11 @@ public class FibonacciLambda {
         }
     }
 
-    private Long fibonacci() {
+    private long fibonacci() {
         return fibonacci(FIBONACCI_PARAMETER);
     }
 
-    private Long fibonacci(Long n) {
+    private long fibonacci(long n) {
         if (n == 0 || n == 1) {
             return n;
         } else {


### PR DESCRIPTION
I saw your InfoQ presentation [1] in which you claim performance scales
linearly with memory size. This is quite suspicious so I checked your
code and noticed that you're using reference instead of primitive
types. This could explain the performance scaling you're observing.

Due to the use of reference over of primitive types your code puts a
lot of pressure on the allocator. Having a heap that's n-times larger
means that you'll have only one n-th of the garbage collections. That's
the trade-off at the core of copy garbage collectors (like serial GC).
The pause time of a garbage collection with a copy collector is
proportional to the size of the live set and independent of the size of
the heap. In your case the size of the live set is constant which means
that garbage collection pauses should be the same length on a large
heap as on a small heap but garbage collections should happen much less
frequently on a large heap.

In the end I believe your benchmark only measures garbage collection
overhead. Having a look at your GC logs should be able to clear this
up.

Also you're wrong about Java class loading. Java class loading is lazy,
classes are only loaded when they're needed. Therefore the number of
classes in the classpath does not affect start up time, only the number
of classes that are needed.

 [1] https://www.infoq.com/presentations/jvm-aws-lambda